### PR TITLE
Fix version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = [
   "requests",
   "cogwatch",
   "transformers[torch]",
-  "discord.py",
+  "discord.py ==1.7.3",
   "python-dotenv"
 ]
 [tool.flit.metadata.requires-extra]


### PR DESCRIPTION
There's a new, incompatible version of python discord which demands async.  This pegs the version until someone gets around to messing with the upgrade